### PR TITLE
Sort package mappings, use path from mappings file

### DIFF
--- a/generate-nuget-package-mappings.sh
+++ b/generate-nuget-package-mappings.sh
@@ -24,7 +24,7 @@ fi
 
 dir=$1
 
-results=$(find $dir -name "*.nupkg")
+results=$(find $dir -name "*.nupkg" | sort)
 
 echo "Package,Target GitHub Repo"
 

--- a/migrate-nuget-packages-to-github.sh
+++ b/migrate-nuget-packages-to-github.sh
@@ -39,5 +39,5 @@ do
     # set target github repo to second column
     target_github_repo=$(echo "$package" | cut -d, -f2)
     echo "Migrating $package_name to $target_github_repo"
-    eval $GPR_PATH push ./$package_name --repository https://github.com/$target_github_repo -k $PAT
+    eval $GPR_PATH push $package_name --repository https://github.com/$target_github_repo -k $PAT
 done


### PR DESCRIPTION
Sort the output of the 'find' command when generating mappings, making the resulting file much easier to edit if you have many packages or package revisions.

Remove `./` from gpr push command, allowing the .nupkg files to be stored in a different directory than the current directory.  The find command in the generate mappings script will output either a relative path or an absolute path depending on how it was called, so we might as well use it as-is.